### PR TITLE
Fixed android client notification with non-latin characters.

### DIFF
--- a/Android/GetStarted/app/src/main/java/com/example/microsoft/getstarted/MainActivity.java
+++ b/Android/GetStarted/app/src/main/java/com/example/microsoft/getstarted/MainActivity.java
@@ -203,7 +203,7 @@ public class MainActivity extends AppCompatActivity {
                         // urlConnection.setRequestProperty("ServiceBusNotification-Tags", "tag1 || tag2 || tag3");
 
                         // Send notification message
-                        urlConnection.setFixedLengthStreamingMode(json.length());
+                        urlConnection.setFixedLengthStreamingMode(json.getBytes().length);
                         OutputStream bodyStream = new BufferedOutputStream(urlConnection.getOutputStream());
                         bodyStream.write(json.getBytes());
                         bodyStream.close();

--- a/Android/GetStartedFirebase/app/src/main/java/com/example/microsoft/getstartednh/MainActivity.java
+++ b/Android/GetStartedFirebase/app/src/main/java/com/example/microsoft/getstartednh/MainActivity.java
@@ -205,7 +205,7 @@ public class MainActivity extends AppCompatActivity {
                         //      "tag1 || tag2 || tag3");
 
                         // Send notification message
-                        urlConnection.setFixedLengthStreamingMode(json.length());
+                        urlConnection.setFixedLengthStreamingMode(json.getBytes().length);
                         OutputStream bodyStream = new BufferedOutputStream(urlConnection.getOutputStream());
                         bodyStream.write(json.getBytes());
                         bodyStream.close();


### PR DESCRIPTION
Android client app fails to send notification with non-latin chracters.
Message bytes won't be calculated accordingly, you can use this arabic word to repro ( عربى ).

![android client exception](https://user-images.githubusercontent.com/1885824/27885222-9aa42d50-61ad-11e7-966f-68707a8f87c1.jpg)
