### PR TITLE
Adding issue template for sample bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,16 @@
+---
+name: Bug Report
+about: Report a problem with a sample.
+title: ''
+---
+
+> STOP: Have you discovered a problem with a sample found here, or are you looking for help getting the sample to work for you?
+>
+> If you're looking for help getting a sample working for you, please ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-notificationhub?tab=newest) with the tag `azure-notificationhub`. You'll be asking a broader community for help, potentially getting you an answer more quickly.
+
+
+## What are you trying to do?
+
+## What did you expect to see?
+
+## What actually happened?


### PR DESCRIPTION
Leaving a breadcrumb to try to get people the help they need most quickly.

By adding an issue template, I hope to nudge people to Stack Overflow with the hopes that this leads to quicker answers and less noise for us.